### PR TITLE
Update tencent-map.js

### DIFF
--- a/ui/src/app/widget/lib/tencent-map.js
+++ b/ui/src/app/widget/lib/tencent-map.js
@@ -365,7 +365,7 @@ export default class TbTencentMap {
 			map: this.map,
 			path: latLangs,
 			strokeColor: settings.polygonStrokeColor,
-			fillColor: settings.polygonColor,
+			fillColor: qq.maps.Color.fromHex(settings.polygonColor, settings.polygonOpacity),
 			strokeWeight: settings.polygonStrokeWeight
 		});
 		//initialize-tooltip
@@ -410,7 +410,7 @@ export default class TbTencentMap {
 			path: polygon.getPath(),
 			map: this.map,
 			strokeColor: color,
-			fillColor: color,
+			fillColor: qq.maps.Color.fromHex(color, settings.polygonOpacity),
 			strokeWeight: settings.polygonStrokeWeight
 		}
 		polygon.setOptions(options);


### PR DESCRIPTION
Solve the problem that the polygonOpacity attribute does not work in Tencent map.